### PR TITLE
Specify Rack::Cors requirement in README

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -18,6 +18,12 @@ Or in your Gemfile:
 gem 'rack-corsgate'
 ```
 
+**Dependencies**
+
+Your application must have `Rack::Cors` available. See: [Rack CORS Middleware](https://github.com/cyu/rack-cors)
+
+Follow the configuration requirements given in its readme.
+
 ## Configuration
 
 CorsGate is actually two middleware functions:


### PR DESCRIPTION
I was trying to use this on a personal project and an explicit mention of the need to install the `Rack::Cors` gem first would have saved me a bit of time.